### PR TITLE
add setting to control non zero exit code warnings

### DIFF
--- a/settings/config.json
+++ b/settings/config.json
@@ -82,6 +82,11 @@
     "compiler_invocation":
         "java -cp {classpath} {compiler_executable} {testcase}",
 
+    // Should yuno issue a warning when the exit code of the compiler executable
+    // is non zero?
+    "warn_on_nonzero_exit_code":
+        false,
+
 
     // Message templates -------------------------------------------------------
 

--- a/yuno/core/testing.py
+++ b/yuno/core/testing.py
@@ -154,12 +154,13 @@ class Test(object):
             # The compiler process halted with a nonzero return code. It's best
             # not to assume this is a total failure, so let's warn them in case
             # they're just misusing exit codes.
-            harness.test_warned(
-                self,
-                "Test `%s` finished with exit code %d." % (
-                    compile_command, e.returncode
+            if config.warn_on_nonzero_exit_code:
+                harness.test_warned(
+                    self,
+                    "Test `%s` finished with exit code %d." % (
+                        compile_command, e.returncode
+                    )
                 )
-            )
             output = e.output
 
         try:


### PR DESCRIPTION
For project 2 I can understand that if the compiler is not exiting with 0 then there is really something wrong going on, but for project 1 many of the test cases are designed so that they should not compile.

It's a bit annoying to be getting tons of warnings for this when I'm fully expecting it to happen.

PS: Thanks for the cool software :+1: :)
