### PR TITLE
Update testing-remotely.rst

### DIFF
--- a/docs/source/testing-remotely.rst
+++ b/docs/source/testing-remotely.rst
@@ -7,6 +7,7 @@ The goal: a local path whose contents automatically get synced in both direction
 
 * `SSHFS <https://www.digitalocean.com/community/articles/how-to-use-sshfs-to-mount-remote-file-systems-over-ssh>`_ (Linux, OS X)
 * `ExpanDrive <http://www.expandrive.com/expandrive>`_ (Windows, OS X)
+* `CloudMounter <http://mac.eltima.com/mount-cloud-drive.html>`_ (OS X)
 * `win-sshfs <https://code.google.com/p/win-sshfs/>`_ (Windows)
 * inotify + rsync hacks
 


### PR DESCRIPTION
I am Alex from Eltima Software. I have added our CloudMounter (SFTP, WebDAV client for Mac) to the list of suggested software in this tutorial article. It allows to mount remote file servers, as well as Google Drive, Dropbox, OneDrive and Amazon S3 accounts, to Mac like local disks.
